### PR TITLE
fix tx fee

### DIFF
--- a/coins/koto.json
+++ b/coins/koto.json
@@ -9,5 +9,5 @@
     "foundersRewardAddressChangeInterval": 17709.3125,
     "vFoundersRewardAddress": [
     ],
-    "txfee": 0.0001
+    "txfee": 0.0004
 }


### PR DESCRIPTION
Maybe this parameter is not tx fee of one transaction.
It's reserve of tx fee.
おそらくですが，このパラメータは一回のtxfeeを指しているのではなく，
txfeeのためにpoolが確保し，minerに分配しない量を指しているのだと思います．
その証拠にtxfeeはソースコード上で採掘分から各minerの取り分を計算するときにしか使われず，
送信時には使われていません．
よってこのパラメータは0.00020xxx以上にする必要があると思われます．
（z_senmanyの固定fee0.0001が2回とsendmanyの変動feeが1回）
他のコインはこれを踏まえて多めに0.0004にしているものだと思われます．
私はjsやpoolについてあまり詳しくないので確認して正しければpullお願いします．