### PR TITLE
change unshield amount at a time

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -297,9 +297,9 @@ function SetupForPool(logger, poolOptions, setupFinished){
         }
 
         var amount = satoshisToCoins(zBalance - 10000);
-        // unshield no more than 100 KOTO at a time
-        if (amount > 100.0)
-            amount = 100.0;
+        // unshield no more than 400 KOTO at a time
+        if (amount > 400.0)
+            amount = 400.0;
 
         var params = [poolOptions.zAddress, [{'address': poolOptions.tAddress, 'amount': amount}]];
         daemon.cmd('z_sendmany', params,


### PR DESCRIPTION
以下の理由により一度にz→t処理する量を増やしてはどうでしょうか。
1. 短時間に多量に掘れた場合、unshield処理に時間がかかり支払い処理が遅延する場合がある
2. プール手数料が0で100Koto以上掘れた場合、unshield処理が2回発生しトランザクション手数料により支払いKotoが不足する可能性がある
